### PR TITLE
Docs: Add missing return descriptions for `WP_Filesystem_SSH2::chown(…

### DIFF
--- a/wp-admin/includes/class-wp-filesystem-ssh2.php
+++ b/wp-admin/includes/class-wp-filesystem-ssh2.php
@@ -193,7 +193,8 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 	 * 
 	 * @param string $command
 	 * @param bool $returnbool
-	 * @return bool|string
+	 * @return bool|string True on success, false on failure. String if the command was executed, `$returnbool`
+	 *                     is false (default), and data from the resulting stream was retrieved.
 	 */
 	public function run_command( $command, $returnbool = false ) {
 		if ( ! $this->link )
@@ -330,10 +331,10 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 	 *
 	 * @access public
 	 *
-	 * @param string     $file    Path to the file.
-	 * @param string|int $owner   A user name or number.
-	 * @param bool       $recursive Optional. If set True changes file owner recursivly. Defaults to False.
-	 * @return bool|string Returns true on success or false on failure.
+	 * @param string     $file      Path to the file.
+	 * @param string|int $owner     A user name or number.
+	 * @param bool       $recursive Optional. If set True changes file owner recursivly. Default False.
+	 * @return bool True on success or false on failure.
 	 */
 	public function chown( $file, $owner, $recursive = false ) {
 		if ( ! $this->exists($file) )

--- a/wp-includes/version.php
+++ b/wp-includes/version.php
@@ -4,7 +4,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '4.6-alpha-37269';
+$wp_version = '4.6-alpha-37270';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
…)`and`WP_Filesystem_SSH2::run_command()`.

Fixes #30989.

Built from https://develop.svn.wordpress.org/trunk@37270

git-svn-id: http://core.svn.wordpress.org/trunk@37236 1a063a9b-81f0-0310-95a4-ce76da25c4cd
